### PR TITLE
Add support for CancelShipment

### DIFF
--- a/lib/mws/merchant_fulfillment/parser.rb
+++ b/lib/mws/merchant_fulfillment/parser.rb
@@ -26,6 +26,9 @@ module MWS
         when /CreateShipment/
           shipment_node = node.children.find { |node| node.name == 'Shipment' }
           Shipment.new(shipment_node)
+        when /CancelShipment/
+          shipment_node = node.children.find { |node| node.name == 'Shipment' }
+          Shipment.new(shipment_node)
         else
           raise NotImplementedError
         end

--- a/lib/mws/merchant_fulfillment/shipment.rb
+++ b/lib/mws/merchant_fulfillment/shipment.rb
@@ -17,7 +17,7 @@ module MWS
 
       attribute(:ship_to_address) do
         node = xpath('ShipToAddress').first
-        Address.new(node)
+        Address.new(node) if node
       end
 
       attribute(:amazon_order_id) do
@@ -26,31 +26,35 @@ module MWS
 
       attribute(:weight) do
         node = xpath('Weight').first
-        Weight.new(node)
+        Weight.new(node) if node
       end
 
       attribute(:label) do
         node = xpath('Label').first
-        Label.new(node)
+        Label.new(node) if node
       end
 
       attribute(:shipping_service) do
         node = xpath('ShippingService').first
-        ShippingService.new(node)
+        ShippingService.new(node) if node
       end
 
       attribute(:package_dimensions) do
         node = xpath('PackageDimensions').first
-        PackageDimensions.new(node)
+        PackageDimensions.new(node) if node
       end
 
       attribute(:created_date) do
         time_at_xpath('CreatedDate')
       end
 
+      attribute(:last_updated_date) do
+        time_at_xpath('LastUpdatedDate')
+      end
+
       attribute(:ship_from_address) do
         node = xpath('ShipFromAddress').first
-        Address.new(node)
+        Address.new(node) if node
       end
 
       attribute(:item_list) do
@@ -67,6 +71,10 @@ module MWS
 
       attribute(:shipment_id) do
         text_at_xpath('ShipmentId')
+      end
+
+      attribute(:seller_order_id) do
+        text_at_xpath('SellerOrderId')
       end
     end
   end


### PR DESCRIPTION
The [CancelShipment](http://docs.developer.amazonservices.com/en_US/merch_fulfill/MerchFulfill_CancelShipment.html) endpoint returns a Shipment object, so we simply need to parse that and account for a few additional fields.

We also shouldn't assume that all elements will have a node.